### PR TITLE
Disable video type detection

### DIFF
--- a/youtubeanalyzer/engine.py
+++ b/youtubeanalyzer/engine.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 import traceback
 import isodate
-import requests
 from PySide6.QtCore import (
     QObject,
     Signal,
@@ -435,15 +434,18 @@ class YoutubeApiEngine(AbstractYoutubeEngine):
         return video_response, channels
 
     def _type(self, vid):
-        url = 'http://www.youtube.com/shorts/' + vid
-        ret = requests.get(url, timeout=100)
-        text = ret.text
-        urlshorts = "//www.youtube.com/shorts/"
-        if (text.find(urlshorts) > 0):
-            type = "shorts"
-        else:
-            type = "longs"
-        return type
+        return "unknown"
+        # The code below is not fast enough to use for a large number of videos in a request.
+        # We can come back to video type detecting if we find a better method for doing so.
+        # url = 'http://www.youtube.com/shorts/' + vid
+        # ret = requests.get(url, timeout=100)
+        # text = ret.text
+        # urlshorts = "//www.youtube.com/shorts/"
+        # if (text.find(urlshorts) > 0):
+        #     type = "shorts"
+        # else:
+        #     type = "longs"
+        # return type
 
     def _responce_item_to_result(self, responce_item, video_item, result_index, channels, publish_time_key, video_id_getter):
         search_snippet = responce_item["snippet"]

--- a/youtubeanalyzer/export.py
+++ b/youtubeanalyzer/export.py
@@ -13,7 +13,8 @@ def exception_column(column: ResultFields):
             column == ResultFields.VideoPreviewLink or
             column == ResultFields.ChannelLogoLink or
             column == ResultFields.VideoTags or
-            column == ResultFields.VideoPreviewImage):
+            column == ResultFields.VideoPreviewImage or
+            column == ResultFields.VideoType):
         return True
     else:
         return False

--- a/youtubeanalyzer/model.py
+++ b/youtubeanalyzer/model.py
@@ -110,13 +110,11 @@ class ResultTableModel(QAbstractTableModel):
             self.tr("Video tag list"),
             self.tr("Video duration timedelta"),
             self.tr("Video relevance in search output (0 is the higest relevance)"),
-            self.tr("Video type"),
             self.tr("Video preview image")
             ]
         self._fields = [
             ResultFields.VideoRelevanceNumber,
             ResultFields.VideoTitle,
-            ResultFields.VideoType,
             ResultFields.VideoPublishedTime,
             ResultFields.VideoDuration,
             ResultFields.VideoViews,

--- a/youtubeanalyzer/video_table_workspace.py
+++ b/youtubeanalyzer/video_table_workspace.py
@@ -57,8 +57,7 @@ from youtubeanalyzer.filters import (
 from youtubeanalyzer.chart import (
     ChannelsPieChart,
     VideoDurationChart,
-    WordsPieChart,
-    VideoTypeChart
+    WordsPieChart
 )
 from youtubeanalyzer.widgets import (
     create_link_label,
@@ -247,7 +246,6 @@ class AnalyticsWidget(QWidget):
         self._chart_combobox.addItem(self.tr("Channels distribution chart"))
         self._chart_combobox.addItem(self.tr("Video duration chart"))
         self._chart_combobox.addItem(self.tr("Popular title words chart"))
-        self._chart_combobox.addItem(self.tr("Video type chart"))
 
         self._chart_combobox.currentIndexChanged.connect(self._on_current_chart_changed)
         main_layout.addWidget(self._chart_combobox)
@@ -264,9 +262,6 @@ class AnalyticsWidget(QWidget):
 
         words_pie_chart = WordsPieChart(proxy_model)
         self._charts.append(words_pie_chart)
-
-        video_type_chart = VideoTypeChart(proxy_model)
-        self._charts.append(video_type_chart)
 
         self._chart_view.setChart(channels_pie_chart)
 


### PR DESCRIPTION
Video type detection is not fast enough to use for a large number of videos in a request. We can come back to video type detecting if we find a better method for doing so.